### PR TITLE
Require specifying api key at twickets client creation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Powers (the similarly creatively named)
 - [Getting an API Key](#getting-an-api-key)
 - [Example Usage](#example-usage)
 - [How does the event name matching/similarity work?](#how-does-the-event-name-matchingsimilarity-work)
-  - [Normalization](#normalization)
+	- [Normalization](#normalization)
 - [Why the name twigots?](#why-the-name-twigots)
 
 ## Installation- [Installation](#installation)
@@ -36,6 +36,11 @@ To use this tool, you will need a Twickets API key. Although Twickets doesn't pr
 This API key is not provided here due to liability concerns, but it appears to be a fixed, unchanging value.
 
 ## Example Usage
+
+> [!Warning]
+> Although this package is functional and ready for use, it is still a work in progress and is subject to change without notice - the API and usage may be modified at any time.
+>
+> Use with caution and check for updates regularly.
 
 Example can be seen in [`example/main.go`](example/main.go) or below:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Powers (the similarly creatively named)
 - [Getting an API Key](#getting-an-api-key)
 - [Example Usage](#example-usage)
 - [How does the event name matching/similarity work?](#how-does-the-event-name-matchingsimilarity-work)
-	- [Normalization](#normalization)
+  - [Normalization](#normalization)
 - [Why the name twigots?](#why-the-name-twigots)
 
 ## Installation- [Installation](#installation)
@@ -55,13 +55,17 @@ import (
 func main() {
 	apiKey := "my_api_key"
 
+	// Create twickets client (using api key)
+	client, err := twigots.NewClient(apiKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Fetch ticket listings
-	client := twigots.NewClient() // Or use a custom http client
 	listings, err := client.FetchTicketListings(
 		context.Background(),
 		twigots.FetchTicketListingsInput{
 			// Required
-			APIKey:  apiKey,
 			Country: twigots.CountryUnitedKingdom, // Only UK is supported at the moment
 			// Optional. See all options in godoc
 			CreatedBefore: time.Now(),

--- a/client_test.go
+++ b/client_test.go
@@ -23,11 +23,12 @@ func TestGetLatestTicketListings(t *testing.T) {
 	twicketsAPIKey := os.Getenv("TWICKETS_API_KEY")
 	require.NotEmpty(t, twicketsAPIKey, "TWICKETS_API_KEY is not set")
 
-	twicketsClient := twigots.NewClient()
+	twicketsClient, err := twigots.NewClient(twicketsAPIKey)
+	require.NoError(t, err)
+
 	listings, err := twicketsClient.FetchTicketListings(
 		context.Background(),
 		twigots.FetchTicketListingsInput{
-			APIKey:  twicketsAPIKey,
 			Country: twigots.CountryUnitedKingdom,
 			Regions: []twigots.Region{
 				twigots.RegionLondon,

--- a/example/main.go
+++ b/example/main.go
@@ -13,13 +13,17 @@ import (
 func main() {
 	apiKey := "my_api_key"
 
+	// Create twickets client (using api key)
+	client, err := twigots.NewClient(apiKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Fetch ticket listings
-	client := twigots.NewClient() // Or use a custom http client
 	listings, err := client.FetchTicketListings(
 		context.Background(),
 		twigots.FetchTicketListingsInput{
 			// Required
-			APIKey:  apiKey,
 			Country: twigots.CountryUnitedKingdom, // Only UK is supported at the moment
 			// Optional. See all options in godoc
 			CreatedBefore: time.Now(),


### PR DESCRIPTION
This means it does not have to be set at fetch time.