### PR TITLE
Do not return listings with a CreatedAt time matching CreatedAfter input when fetching

### DIFF
--- a/client.go
+++ b/client.go
@@ -170,14 +170,15 @@ func (c *Client) FetchTicketListings(
 			numListingsRemaining, input.CreatedAfter,
 		)
 
-		// Update loop variables
+		// Update listings
 		listings = append(listings, newListings...)
-		numListingsRemaining = input.MaxNumber - len(listings)
-		earliestTicketTime = listings[len(listings)-1].CreatedAt.Time
-
 		if shouldBreak {
 			break
 		}
+
+		// Update loop variables
+		numListingsRemaining = input.MaxNumber - len(listings)
+		earliestTicketTime = listings[len(listings)-1].CreatedAt.Time
 	}
 
 	return listings, nil
@@ -195,8 +196,8 @@ func processFeedListings(
 	processedListings := make([]TicketListing, 0, len(listings))
 	for _, listing := range listings {
 
-		// If listing created before the earliest allowed time, break
-		if listing.CreatedAt.Before(createdAfter) {
+		// If listing NOT created after the earliest allowed time, break
+		if !listing.CreatedAt.After(createdAfter) {
 			return processedListings, true
 		}
 


### PR DESCRIPTION
There was a bug in the fetch ticket listings function, where tickets with `CreatedAt` time that was equal to the `CreatedAfter` input were being returned. This is a is not wanted (and is a bug) as this is the way we can properly paginate tickets when calling the fetch function multiple times. Specifically, this caused an issue in `twichets` where the same ticket would be notified of many times.

As a result of looking into this bug, it came to my attention that there are never duplicate listings on `twickets`, and the duplicates I had been seeing, and the reason for the addition of duplicate recognition and ignoring logic was actually down to this issue, not actual duplicates in the listings.