### PR TITLE
Fix "request cannot be satisfied" CloudFlare error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,19 @@
   "go.lintTool": "golangci-lint",
 
   // ---- Plugin Settings ----
-  "cSpell.words": ["twickets"],
+  "cSpell.words": [
+    "ahobsonsayers",
+    "delisted",
+    "godotenv",
+    "httpmock",
+    "nolint",
+    "testutils",
+    "twickets",
+    "twigots",
+    "uneeded",
+    "unparam",
+    "utilopia"
+  ],
   "emeraldwalk.runonsave": {
     "commands": [
       {

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/imroc/req/v3"
 	"github.com/k3a/html2text"
-	"github.com/samber/lo"
 )
 
 type Client struct {
@@ -56,14 +55,6 @@ type FetchTicketListingsInput struct {
 	// Set this to fetch listings within a time period.
 	// Defaults to current time.
 	CreatedBefore time.Time
-
-	// NumPerRequest is the number of ticket listings to fetch in each request.
-	// Not all requested listings are fetched at once - instead a series of requests are made,
-	// each fetching the number of listings specified here. In theory this can be arbitrarily
-	// large to prevent having to make too many requests, however it has been known that any
-	// other number than 10 can sometimes not work.
-	// Defaults to 10. Usually can be ignored.
-	NumPerRequest int
 }
 
 func (f *FetchTicketListingsInput) applyDefaults() {
@@ -72,9 +63,6 @@ func (f *FetchTicketListingsInput) applyDefaults() {
 	}
 	if f.CreatedBefore.IsZero() {
 		f.CreatedBefore = time.Now()
-	}
-	if f.NumPerRequest <= 0 {
-		f.NumPerRequest = 10
 	}
 }
 
@@ -142,11 +130,10 @@ func (c *Client) FetchTicketListings(
 
 		// Get feed url
 		feedUrl, err := FeedUrl(FeedUrlInput{
-			APIKey:      c.apiKey,
-			Country:     input.Country,
-			Regions:     input.Regions,
-			BeforeTime:  earliestTicketTime,
-			NumListings: lo.Min([]int{input.NumPerRequest, numListingsRemaining}),
+			APIKey:     c.apiKey,
+			Country:    input.Country,
+			Regions:    input.Regions,
+			BeforeTime: earliestTicketTime,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get feed url: %w", err)

--- a/client_test.go
+++ b/client_test.go
@@ -222,7 +222,12 @@ func getMockUrlAndResponder(
 	startTime time.Time,
 	interval time.Duration, // nolint:unparam
 ) (string, httpmock.Responder) {
-	url := getMockUrl(events, startTime)
+	url := fmt.Sprintf(
+		"https://www.twickets.live/services/catalogue?api_key=%s&count=10&maxTime=%d&q=countryCode=%s",
+		testAPIKey,
+		startTime.UnixMilli(),
+		twigots.CountryUnitedKingdom.Value,
+	)
 	response := getMockResponse(events, startTime, interval)
 
 	// Marshal response
@@ -236,16 +241,6 @@ func getMockUrlAndResponder(
 	}
 
 	return url, responder
-}
-
-func getMockUrl(events []string, startTime time.Time) string {
-	return fmt.Sprintf(
-		"https://www.twickets.live/services/catalogue?api_key=%s&count=%d&maxTime=%d&q=countryCode=%s",
-		testAPIKey,
-		len(events),
-		startTime.UnixMilli(),
-		twigots.CountryUnitedKingdom.Value,
-	)
 }
 
 func getMockResponse(events []string, startTime time.Time, interval time.Duration) map[string]any {

--- a/url.go
+++ b/url.go
@@ -27,8 +27,7 @@ func init() {
 	}
 }
 
-// ListingURL gets the url of a listing given its id and the
-// number of tickets in the listing.
+// ListingURL gets the url of a listing given its id and the number of tickets in the listing.
 //
 // Format is:
 // https://www.twickets.live/app/block/<ticketId>,<numTickets>
@@ -44,9 +43,8 @@ type FeedUrlInput struct {
 	Country Country
 
 	// Optional fields
-	Regions     []Region  // Defaults to all country regions
-	NumListings int       // Defaults to 10 ticket listings
-	BeforeTime  time.Time // Defaults to current time
+	Regions    []Region  // Defaults to all country regions
+	BeforeTime time.Time // Defaults to current time
 }
 
 // Validate the input struct used to get the feed url.
@@ -64,9 +62,12 @@ func (f FeedUrlInput) Validate() error {
 	return nil
 }
 
-// FeedUrl gets the url of a feed of ticket listings
+// FeedUrl gets the url of a ticket listings feed.
+// Note: The number of ticket listings (that are non-delisted) in the feed at this url will ALWAYS be 10.
+// There may be any number of additional delisted ticket listings.
 //
-// Format is: https://www.twickets.live/services/catalogue?q=countryCode=GB&count=100&api_key=<api_key>
+// Format is:
+// https://www.twickets.live/services/catalogue?q=countryCode=GB&count=10&api_key=<api_key>
 func FeedUrl(input FeedUrlInput) (string, error) {
 	err := input.Validate()
 	if err != nil {
@@ -89,12 +90,8 @@ func FeedUrl(input FeedUrlInput) (string, error) {
 		queryParams.Set("maxTime", strconv.Itoa(int(maxTime)))
 	}
 
-	if input.NumListings > 0 {
-		count := strconv.Itoa(input.NumListings)
-		queryParams.Set("count", count)
-	}
-
 	queryParams.Set("api_key", input.APIKey)
+	queryParams.Set("count", "10") // count must always be 10 to not get an error
 
 	// Set query
 	encodedQuery := queryParams.Encode()


### PR DESCRIPTION
Recently, I have been seeing a `403 - The request could not be satisfied` error from Cloudflare in `twitchets`. I have discovered that this happens when the `count` query param in the feed url is set to anything else than exactly `10` - which would occasionally happen (particularly in `twitchets`) due to the `math.Min` I was using in the input to the feed url function.

Therefore, to fix this, we are now enforcing that the number of (non-delisted) tickets that will be the feed (at the url) will always be `10` via hard-coding the `count` query param. You can still specify to get non-multiples of 10 when fetching tickets, and they will be trimmed down to the number requested.

Should fix https://github.com/ahobsonsayers/twitchets/issues/15