### PR TITLE
Make sure enums marshal properly to strings

### DIFF
--- a/location.go
+++ b/location.go
@@ -33,6 +33,10 @@ func (c *Country) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (c Country) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Value)
+}
+
 func (c *Country) UnmarshalText(data []byte) error {
 	countryString := string(data)
 	country := Countries.Parse(countryString)
@@ -45,6 +49,10 @@ func (c *Country) UnmarshalText(data []byte) error {
 }
 
 type Region enum.Member[string]
+
+func (r Region) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.Value)
+}
 
 func (r *Region) UnmarshalJSON(data []byte) error {
 	var regionString string

--- a/location_test.go
+++ b/location_test.go
@@ -1,0 +1,20 @@
+package twigots
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountryMarshalJSON(t *testing.T) {
+	data, err := json.Marshal(CountryUnitedKingdom)
+	require.NoError(t, err)
+	require.Equal(t, `"GB"`, string(data))
+}
+
+func TestRegionMarshalJSON(t *testing.T) {
+	data, err := json.Marshal(RegionLondon)
+	require.NoError(t, err)
+	require.Equal(t, `"GBLO"`, string(data))
+}

--- a/price.go
+++ b/price.go
@@ -110,3 +110,7 @@ func (c *Currency) UnmarshalJSON(data []byte) error {
 	*c = *currency
 	return nil
 }
+
+func (c Currency) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Value)
+}

--- a/price_test.go
+++ b/price_test.go
@@ -1,0 +1,14 @@
+package twigots
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrencyMarshalJSON(t *testing.T) {
+	data, err := json.Marshal(CurrencyGBP)
+	require.NoError(t, err)
+	require.Equal(t, `"GBP"`, string(data))
+}


### PR DESCRIPTION
Adds custom `MarshalJSON` to enums, so they properly marshal to strings, not objects with a `Value` key